### PR TITLE
Exclude generated coverage files from linting.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,6 @@
 # Distributed Files
 dist/
 node_modules/
+
+# Generated coverage report
+coverage/


### PR DESCRIPTION
Closes #9

When running linting locally, eslint would previously find errors in the files generated by coverage.