### PR TITLE
Add custom button component

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,17 @@
+import { Text } from './typography';
+
+
+const Button = Text.withComponent('button').extend`
+  background: ${props => props.theme.colors.accentGray};
+  border: 0;
+  border-radius: ${props => props.theme.borderRadius};
+  cursor: pointer;
+  padding: .5em 1em;
+
+  &:hover {
+    background: #bbb;
+  }
+`;
+
+
+export default Button;

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 
 export const StyledInput = styled.input`
-  border: 1px solid #e2e2e2;
+  border: 1px solid ${props => props.theme.colors.accentGray};
   border-radius: ${props => props.theme.borderRadius};
   display: block;
   font-family: ${props => props.theme.fonts.families.body};

--- a/src/components/RegistrationForm.jsx
+++ b/src/components/RegistrationForm.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 
 import { register } from '../actionCreators';
+import Button from './Button';
 import Field from './Field';
 import { getRegistrationComplete, getRegistrationErrors, getRegistrationLoading } from '../selectors';
 
@@ -60,12 +61,12 @@ export class RegistrationForm extends React.Component {
           type="password"
         />
 
-        <button
+        <Button
           disabled={this.props.isLoading}
           type="submit"
         >
           Register
-        </button>
+        </Button>
       </form>
     );
   }

--- a/src/components/__tests__/Button.spec.jsx
+++ b/src/components/__tests__/Button.spec.jsx
@@ -1,0 +1,30 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import defaultTheme from '../../styles/theme';
+
+import Button from '../Button';
+
+
+const setup = ({ theme = defaultTheme } = {}) => {
+  const props = {
+    theme,
+  };
+  const wrapper = shallow(<Button {...props} />);
+
+  return {
+    props,
+    wrapper,
+  };
+};
+
+
+describe('Button Component', () => {
+  it('should pull some styles from the theme', () => {
+    const { props, wrapper } = setup();
+    const { theme } = props;
+
+    expect(wrapper).toHaveStyleRule('background', theme.colors.accentGray);
+    expect(wrapper).toHaveStyleRule('border-radius', theme.borderRadius);
+  });
+});

--- a/src/components/__tests__/Input.spec.jsx
+++ b/src/components/__tests__/Input.spec.jsx
@@ -24,6 +24,7 @@ describe('StyledInput Component', () => {
   it('should pull some properties from its theme', () => {
     const wrapper = shallow(<StyledInput theme={theme} />);
 
+    expect(wrapper).toHaveStyleRule('border', `1px solid ${theme.colors.accentGray}`);
     expect(wrapper).toHaveStyleRule('border-radius', theme.borderRadius);
     expect(wrapper).toHaveStyleRule('font-family', theme.fonts.families.body.replace(', ', ','));
     expect(wrapper).toHaveStyleRule('line-height', theme.fonts.lineHeight.toString());

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,5 +1,8 @@
 export default {
   borderRadius: '3px',
+  colors: {
+    accentGray: '#ddd',
+  },
   fonts: {
     families: {
       body: "'Open Sans', sans-serif",


### PR DESCRIPTION
Addresses #20 

This PR adds a custom styled button component. The button can be used to replace `<button>` or `<a>` tags.